### PR TITLE
update manaba-url for kait

### DIFF
--- a/docs/host-list/index.md
+++ b/docs/host-list/index.md
@@ -39,7 +39,7 @@
 - 金城学院大学 [->](https://kinjo.manaba.jp/ct/home_course)
 - 鹿児島大学 [->](https://www.kagoshima-u.ac.jp/manaba/manaba.html)
 - 関東学院大学 [->](https://univ.kanto-gakuin.ac.jp/students.html)
-- 神奈川工科大学 [->](https://kait.manaba.jp/)
+- 神奈川工科大学 [->](https://kaitc2.manaba.jp/ct/)
 - 日本女子大学 [->](https://manaba.jwu.ac.jp/ct/login)
 - 順天堂大学 [->](https://med-lms.juntendo.ac.jp/ct/login?lang=ja)
 - 城西国際大学 [->](https://www.jiu.ac.jp/johocenter/20/4_manaba.htm)

--- a/hosts/kait.json
+++ b/hosts/kait.json
@@ -1,12 +1,11 @@
 {
     "name": "神奈川工科大学",
-    "source": "https://kait.manaba.jp/",
+    "source": "https://kaitc2.manaba.jp/ct/",
     "tags": [
         "#春からKAIT",
         "#春から神奈川工科",
         "#春から神奈川工科大学"
     ],
-    
-    "manaba-url": "https://kait.manaba.jp/ct",
+    "manaba-url": "https://kaitc2.manaba.jp/ct/",
     "bad-status": []
 }


### PR DESCRIPTION
現在神奈川工科大学で利用されているmanabaのURLに変更しました。